### PR TITLE
[feat/errhandler] 예외 컨트롤러 구현

### DIFF
--- a/src/main/java/com/daily/timotae/constant/ErrorCode.java
+++ b/src/main/java/com/daily/timotae/constant/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.daily.timotae.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/daily/timotae/controller/ExceptionController.java
+++ b/src/main/java/com/daily/timotae/controller/ExceptionController.java
@@ -1,0 +1,42 @@
+package com.daily.timotae.controller;
+
+
+import com.daily.timotae.constant.ErrorCode;
+import com.daily.timotae.exception.post.NoSuchPostExist;
+import com.daily.timotae.exception.post.NotSupportSuchTypeException;
+import com.daily.timotae.exception.reply.NoMoreReply;
+import com.daily.timotae.exception.reply.NoParentReplyExist;
+import com.daily.timotae.global.api.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class ExceptionController extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(NoSuchPostExist.class)
+    public ApiResponse handleNoSuchPostExist(NoSuchPostExist e){
+        final ErrorCode errorCode = ErrorCode.RESOURCE_NOT_FOUND;
+        return ApiResponse.error(errorCode.name(), errorCode.getHttpStatus(), errorCode.getMessage());
+    }
+
+    @ExceptionHandler(NotSupportSuchTypeException.class)
+    public ApiResponse handleNotSupportSuchTypeException(NotSupportSuchTypeException e){
+        final ErrorCode errorCode = ErrorCode.RESOURCE_NOT_FOUND;
+        return ApiResponse.error(errorCode.name(), errorCode.getHttpStatus(), errorCode.getMessage());
+    }
+
+    @ExceptionHandler(NoParentReplyExist.class)
+    public ApiResponse handleNoParentReplyExist(NoParentReplyExist e){
+        final ErrorCode errorCode = ErrorCode.RESOURCE_NOT_FOUND;
+        return ApiResponse.error(errorCode.name(), errorCode.getHttpStatus(), errorCode.getMessage());
+    }
+
+    @ExceptionHandler(NoMoreReply.class)
+    public ApiResponse handleNoMoreReply(NoMoreReply e){
+        final ErrorCode errorCode = ErrorCode.RESOURCE_NOT_FOUND;
+        return ApiResponse.error(errorCode.name(), errorCode.getHttpStatus(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/daily/timotae/exception/post/NoSuchPostExist.java
+++ b/src/main/java/com/daily/timotae/exception/post/NoSuchPostExist.java
@@ -1,0 +1,8 @@
+package com.daily.timotae.exception.post;
+
+public class NoSuchPostExist extends RuntimeException{
+    private static final String MESSAGE = "존재하지 않는 게시글입니다.";
+    public NoSuchPostExist() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/daily/timotae/global/api/ApiResponse.java
+++ b/src/main/java/com/daily/timotae/global/api/ApiResponse.java
@@ -2,21 +2,22 @@ package com.daily.timotae.global.api;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public class ApiResponse<T> {
 
     private String code;
-    private int httpStatus;
+    private HttpStatus httpStatus;
     private String message;
     private T response;
 
-    public static <T> ApiResponse success(String code, int httpStatus, String message, T response) {
+    public static <T> ApiResponse success(String code, HttpStatus httpStatus, String message, T response) {
         return new ApiResponse<>(code, httpStatus, message, response);
     }
 
-    public static ApiResponse error(String code, int httpStatus, String message) {
+    public static ApiResponse error(String code, HttpStatus httpStatus, String message) {
         return new ApiResponse<>(code, httpStatus, message, null);
     }
 }

--- a/src/main/java/com/daily/timotae/repository/JpaPostRepositoryAdapter.java
+++ b/src/main/java/com/daily/timotae/repository/JpaPostRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.daily.timotae.repository;
 
 import com.daily.timotae.constant.SearchType;
 import com.daily.timotae.domain.Post;
+import com.daily.timotae.exception.post.NoSuchPostExist;
 import com.daily.timotae.exception.post.NotSupportSuchTypeException;
 import org.springframework.stereotype.Component;
 
@@ -34,7 +35,7 @@ public class JpaPostRepositoryAdapter implements PostRepository {
     @Override
     public void changePost(Long postId, Post post) {
         Post newPost = findPostOne(postId)
-                .orElseThrow( () -> new IllegalArgumentException(POST_NOT_EXIST + postId));
+                .orElseThrow( () -> new NoSuchPostExist());
         newPost.update(post.getTitle(), post.getCategory(), post.getUserId(), post.getContent());
     }
 

--- a/src/main/java/com/daily/timotae/repository/JpaPostRepositoryAdapter.java
+++ b/src/main/java/com/daily/timotae/repository/JpaPostRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.daily.timotae.constant.SearchType;
 import com.daily.timotae.domain.Post;
 import com.daily.timotae.exception.post.NoSuchPostExist;
 import com.daily.timotae.exception.post.NotSupportSuchTypeException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.awt.print.Pageable;
@@ -13,9 +14,10 @@ import java.util.Optional;
 import static com.daily.timotae.constant.PostConstant.POST_NOT_EXIST;
 
 @Component
+@RequiredArgsConstructor
 public class JpaPostRepositoryAdapter implements PostRepository {
 
-    private JpaPostRepository jpaPostRepository;
+    private final JpaPostRepository jpaPostRepository;
 
     @Override
     public Post savePost(Post post) {

--- a/src/main/java/com/daily/timotae/repository/JpaReplyRepositoryAdapter.java
+++ b/src/main/java/com/daily/timotae/repository/JpaReplyRepositoryAdapter.java
@@ -2,6 +2,8 @@ package com.daily.timotae.repository;
 
 import com.daily.timotae.domain.Post;
 import com.daily.timotae.domain.Reply;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Required;
 import org.springframework.stereotype.Component;
 
 import java.awt.print.Pageable;
@@ -12,9 +14,10 @@ import static com.daily.timotae.constant.PostConstant.POST_NOT_EXIST;
 import static com.daily.timotae.constant.ReplyConstant.REPLY_NOT_EXIST;
 
 @Component
+@RequiredArgsConstructor
 public class JpaReplyRepositoryAdapter implements ReplyRepository{
 
-    private JpaReplyRepository jpaReplyRepository;
+    private final JpaReplyRepository jpaReplyRepository;
 
     @Override
     public Reply saveReply(Reply reply) {


### PR DESCRIPTION
* 예외 컨트롤러 구현
  - ExceptionController 구현 -> ExceptionHandler 로 하려고 했는데 @ExceptionHandler 어노테이션이랑 겹쳐서 일단 이렇게 지음
  - Adapter 에서 IllegalArgumentException 을 더 구체화 한 예외처리를 하도록 변경 (NoSuchPostExist)
  - ApiResponse 의 httpStatus 를 int 형에서 HttpStatus 로 변경

* Postman Api test는 하지 않음
  - 추후 PostController, ReplyController 를 ApiResponse 형식으로 바꾼 후 같이 api test 할 예정